### PR TITLE
Test framework added

### DIFF
--- a/GoNOW/__mocks__/expo-sqlite.js
+++ b/GoNOW/__mocks__/expo-sqlite.js
@@ -1,0 +1,9 @@
+export const openDatabaseAsync = jest.fn(async () => ({
+    execAsync: jest.fn(async () => Promise.resolve()),
+    getAllAsync: jest.fn(async () => Promise.resolve([])),
+    runAsync: jest.fn(async () => Promise.resolve()),
+  }));
+  
+  export const openDatabaseSync = jest.fn(() => ({
+    execAsync: jest.fn(async () => Promise.resolve()),
+  }));

--- a/GoNOW/__tests__/database.test.js
+++ b/GoNOW/__tests__/database.test.js
@@ -1,0 +1,47 @@
+import { initializeDatabase, getDailyEvents, clearEvents, getWeeklyEvents, addEvent } from "../app/scripts/database";
+import * as SQLite from "expo-sqlite";
+
+jest.mock("expo-sqlite");
+
+describe("Database Functions", () => {
+  
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test("initializeDatabase should create a table", async () => {
+        await initializeDatabase();
+
+        expect(SQLite.openDatabaseAsync).toHaveBeenCalledWith("userEvents.db");
+        const dbMock = await SQLite.openDatabaseAsync.mock.results[0].value;
+        expect(dbMock.execAsync).toHaveBeenCalledWith(expect.stringContaining("CREATE TABLE IF NOT EXISTS events"));
+    });
+
+    test("should retrieve today's events", async () => {
+        const mockResult = [{ id: 1, name: "Test Event", startTime: Date.now().toString() }];
+        
+        // Mock the return value of SQLite.openDatabaseAsync
+        const mockDB = {
+        getAllAsync: jest.fn().mockResolvedValue(mockResult),
+        };
+        SQLite.openDatabaseAsync.mockResolvedValue(mockDB);  // Return the mock DB object when openDatabaseAsync is called
+
+        // Call the actual function you want to test
+        const events = await getDailyEvents();
+
+        // Assert that the returned events are equal to the mock result
+        expect(events).toEqual(mockResult);
+        
+        // Verify that getAllAsync was called
+        expect(mockDB.getAllAsync).toHaveBeenCalled();
+        });
+
+    test("clearEvents should drop the events table", async () => {
+        await clearEvents();
+
+        expect(SQLite.openDatabaseSync).toHaveBeenCalledWith("userEvents.db");
+        const dbMock = SQLite.openDatabaseSync.mock.results[0].value;
+        expect(dbMock.execAsync).toHaveBeenCalledWith(expect.stringContaining("DROP TABLE events"));
+    });
+
+});

--- a/GoNOW/__tests__/navigator.test.js
+++ b/GoNOW/__tests__/navigator.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import Navigator from '../app/screens/Navigator';
+
+// Mock all the screen components
+jest.mock('../app/screens/MapScreen', () => () => null);
+jest.mock('../app/screens/DailyScreen', () => () => null);
+jest.mock('../app/screens/CreateTaskScreen', () => () => null);
+jest.mock('../app/screens/CalendarScreen', () => () => null);
+jest.mock('../app/screens/ProfileScreen', () => () => null);
+
+// Mock the Ionicons component
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: 'Ionicons'
+}));
+
+describe('TabNavigator', () => {
+
+  it('has correct screen options', () => {
+    const { queryByText } = render(
+      <NavigationContainer>
+        <Navigator />
+      </NavigationContainer>
+    );
+
+    // CreateTask should not be visible in the tab bar
+    expect(queryByText('CreateTask')).toBeNull();
+  });
+
+  // Test custom tab bar rendering
+  it('renders custom tab bar with correct icons', () => {
+    const { getAllByTestId } = render(
+      <NavigationContainer>
+        <Navigator />
+      </NavigationContainer>
+    );
+
+    const icons = getAllByTestId('tab-icon');
+    expect(icons).toHaveLength(5);
+  });
+});

--- a/GoNOW/app/index.tsx
+++ b/GoNOW/app/index.tsx
@@ -1,4 +1,4 @@
-import TabNavigator from './screens/Navigator';
+import Navigator from './screens/Navigator';
 import { useEffect } from 'react';
 import {initializeDatabase, getDailyEvents, clearEvents, addEvent} from './scripts/database';
 
@@ -26,6 +26,6 @@ useEffect(() => {
   setupDatabase();
 }, []);
   return (
-    <TabNavigator></TabNavigator>
+    <Navigator/>
   );
 }

--- a/GoNOW/app/screens/Navigator.tsx
+++ b/GoNOW/app/screens/Navigator.tsx
@@ -41,7 +41,8 @@ const CustomTabBar = ({ state, descriptors, navigation }) => {
             onPress={onPress}
             style={styles.tabButton}
           >
-            <Ionicons 
+            <Ionicons
+              testID="tab-icon"
               name={iconName} 
               size={24} 
               color={isFocused ? '#007AFF' : '#8E8E8F'}
@@ -61,7 +62,7 @@ const CustomTabBar = ({ state, descriptors, navigation }) => {
   );
 };
 
-export default function TabNavigator() {
+export default function Navigator() {
   return (
     <Tab.Navigator
       tabBar={(props) => <CustomTabBar {...props} />}

--- a/GoNOW/package-lock.json
+++ b/GoNOW/package-lock.json
@@ -40,10 +40,12 @@
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@testing-library/jest-native": "^5.4.3",
+        "@testing-library/react-native": "^13.0.1",
         "@types/jest": "^29.5.12",
         "@types/react": "~18.3.12",
         "@types/react-test-renderer": "^18.3.0",
-        "jest": "^29.2.1",
+        "jest": "^29.7.0",
         "jest-expo": "~52.0.3",
         "react-test-renderer": "18.3.1",
         "typescript": "^5.3.3"
@@ -4155,6 +4157,53 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@testing-library/jest-native": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.3.tgz",
+      "integrity": "sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==",
+      "deprecated": "DEPRECATED: This package is no longer maintained.\nPlease use the built-in Jest matchers available in @testing-library/react-native v12.4+.\n\nSee migration guide: https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "jest-diff": "^29.0.1",
+        "jest-matcher-utils": "^29.0.1",
+        "pretty-format": "^29.0.3",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.0.1.tgz",
+      "integrity": "sha512-sKMRNNniSOZ68qe1OBQAWvK87WCEmbfLp/MXfn2JE3x3WrNU8OFCVL0z/YKqw0/JO/d44J8Wq6FmRSaod/+VAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "jest-matcher-utils": "^29.7.0",
+        "pretty-format": "^29.7.0",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -8214,6 +8263,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10216,6 +10266,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -11825,6 +11885,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -12833,6 +12907,19 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/GoNOW/package.json
+++ b/GoNOW/package.json
@@ -12,7 +12,10 @@
     "lint": "expo lint"
   },
   "jest": {
-    "preset": "jest-expo"
+    "preset": "jest-expo",
+    "moduleNameMapper": {
+      "expo-sqlite": "<rootDir>/__mocks__/expo-sqlite.js"
+    }
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",

--- a/GoNOW/package.json
+++ b/GoNOW/package.json
@@ -50,10 +50,12 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@testing-library/jest-native": "^5.4.3",
+    "@testing-library/react-native": "^13.0.1",
     "@types/jest": "^29.5.12",
     "@types/react": "~18.3.12",
     "@types/react-test-renderer": "^18.3.0",
-    "jest": "^29.2.1",
+    "jest": "^29.7.0",
     "jest-expo": "~52.0.3",
     "react-test-renderer": "18.3.1",
     "typescript": "^5.3.3"


### PR DESCRIPTION
Created __mocks__ and __tests__ directory to support jest testing.

To perform tests, run `npx jest` in terminal. 

## Auxiliary Functions:

Simple auxiliary functions can be called in the following manner:

`test('purpose of test here', ()=>{ expect(foo()).toBe('bar')};`

This calls the function foo and will raise an alert if its value is not equal to 'bar'.

Simulated async functions go in the __mocks__ directory, such as database queries and http requests. This allows for simulation of different promise resolve/reject scnearios.  Mock scripts must also be added to the `moduleNameMapper` in `package.json` so jest knows where to find the mock script. 

## Component Rendering:

Can render sample components and query text elements, quantity of child components,  and assign testID's to be checked during testing.