### PR TITLE
Lock rendering until DB initializes

### DIFF
--- a/GoNOW/app/index.tsx
+++ b/GoNOW/app/index.tsx
@@ -1,20 +1,48 @@
-import Navigator from './screens/Navigator';
-import { useEffect, JSX } from 'react';
+import { JSX, useEffect, useState } from 'react';
+import { ActivityIndicator, Linking, Text, TouchableOpacity, View } from 'react-native';
+
 import { initDatabase } from './scripts/Database';
+import { IndexStyles as styles } from './styles/Index.styles';
+import Navigator from './screens/Navigator';
 
 export default function Index(): JSX.Element {
-  
-useEffect(() => {
-  const appInit = async (): Promise<void> => {
+  const [status, setStatus] = useState<number>(0); // 0 - loading; 1 - ready; 2 - error
+
+  useEffect(() => {
+    const appInit = async (): Promise<void> => {
       try {
-          await initDatabase();
+        await initDatabase();
+        setStatus(1);
       } catch (error) {
-          console.error('Error in initializing app:', error);
+        setStatus(2);
+        console.error('Error in initializing app:', error);
       }
-  };
-  void appInit();
-}, []);
-  return (
-    <Navigator/>
-  );
+    };
+    void appInit();
+  }, []);
+
+  return status === 1 // 0 - loading; 1 - ready; 2 - error
+    ? (<Navigator/>)
+    : status === 0
+      ? (
+          <View style={styles.loading}>
+            <ActivityIndicator size="large" />
+            <Text>Loading...</Text>
+          </View>
+        )
+      : (
+          <View style={styles.loading}>
+            <Text>Something went wrong</Text>
+            <Text>¯\_(ツ)_/¯</Text>
+            <Text> </Text>
+            <Text>
+              <TouchableOpacity onPress={() =>
+                {void Linking.openURL('https://walterchen352.github.io/');}}
+              >
+                <Text style={styles.link}>Get help here</Text>
+              </TouchableOpacity>
+            </Text>
+          </View>
+        )
+    ;
 }

--- a/GoNOW/app/styles/Index.styles.ts
+++ b/GoNOW/app/styles/Index.styles.ts
@@ -1,0 +1,17 @@
+import { StyleSheet } from 'react-native';
+
+export const IndexStyles = StyleSheet.create({
+  loading: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  link: {
+    color: 'blue',
+    textDecorationLine: 'underline',
+    padding: 0,
+    margin: 0,
+  }
+});
+
+export default IndexStyles;


### PR DESCRIPTION
Some `useEffect` on some screen may start before DB initializes completely. DB must initialize before rendering any screen or component.